### PR TITLE
feat: integração inicial com Supabase (camada de API + página responder)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+# Opcional para gerar links de convite (fallback = window.location.origin)
+NEXT_PUBLIC_APP_URL=

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # Climatrix
+
 Analisador de Riscos Climáticos
+
+## Variáveis de ambiente
+
+Crie um arquivo `.env.local` (não versionado) ou configure as variáveis no provedor de deploy com os valores do projeto Supabase:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `NEXT_PUBLIC_APP_URL` *(opcional; usado para gerar links de convite. O fallback é `window.location.origin`)*
+
+Utilize o arquivo `.env.example` como referência para preencher esses valores.

--- a/climada-demo/package-lock.json
+++ b/climada-demo/package-lock.json
@@ -8,6 +8,7 @@
       "name": "climada-demo",
       "version": "0.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.57.4",
         "leaflet": "^1.9.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1244,6 +1245,80 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.6",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.1"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1297,6 +1372,21 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "24.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.1.tgz",
+      "integrity": "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.12.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
@@ -1313,6 +1403,15 @@
       "dev": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2470,6 +2569,12 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2481,6 +2586,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -2595,6 +2706,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2617,6 +2744,27 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/climada-demo/package.json
+++ b/climada-demo/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.57.4",
     "leaflet": "^1.9.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/climada-demo/src/lib/adminHandlers.ts
+++ b/climada-demo/src/lib/adminHandlers.ts
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+import { addDestinatarios, createProjeto, listRespostasPorProjeto, validarResposta } from '@/lib/esgApi';
+
+type DestinatarioInput = { nome: string; cargo?: string; email: string; token?: string };
+
+type UseProjetoHandlersParams = {
+  onLinksGerados?: (links: { email: string; token: string; link: string }[]) => void;
+};
+
+export function useProjetoHandlers(params: UseProjetoHandlersParams = {}) {
+  const handleSalvarProjeto = useCallback(
+    async ({ nomeProjeto, nomeCliente, destinatariosLista }: { nomeProjeto: string; nomeCliente: string; destinatariosLista: DestinatarioInput[] }) => {
+      const projeto = await createProjeto({ nome_projeto: nomeProjeto, nome_cliente: nomeCliente });
+      const { links } = await addDestinatarios(projeto.id, destinatariosLista);
+      params.onLinksGerados?.(links);
+      return { projetoId: projeto.id, links };
+    },
+    [params],
+  );
+
+  return { handleSalvarProjeto };
+}
+
+export function useConsultaHandlers() {
+  const carregarRespostas = useCallback(async (projetoId: string) => {
+    return await listRespostasPorProjeto(projetoId);
+  }, []);
+
+  const marcarValidado = useCallback(async (respostaId: string, valor = true) => {
+    await validarResposta(respostaId, valor);
+  }, []);
+
+  return { carregarRespostas, marcarValidado };
+}

--- a/climada-demo/src/lib/esgApi.ts
+++ b/climada-demo/src/lib/esgApi.ts
@@ -1,0 +1,96 @@
+import { supabase } from './supabaseClient';
+
+export type ProjetoInput = { nome_projeto: string; nome_cliente: string; admin_id?: string | null };
+export type Projeto = { id: string; nome_projeto: string; nome_cliente: string; created_at?: string };
+
+export type NovoDestinatario = { nome: string; cargo?: string; email: string; token?: string };
+export type Destinatario = { id: string; projeto_id: string; nome: string; cargo?: string|null; email: string; token: string; respondido?: boolean|null };
+
+export type RespostaPayload = Record<string, any>;
+export type Resposta = { id: string; projeto_id: string; destinatario_id?: string|null; respostas_conteudo: any; validado: boolean; data_resposta?: string };
+
+const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+
+export function buildResponderLink(token: string) {
+  if (typeof window !== 'undefined' && !appUrl) {
+    return `${window.location.origin}/responder?token=${encodeURIComponent(token)}`;
+  }
+  return `${appUrl?.replace(/\/$/, '') || ''}/responder?token=${encodeURIComponent(token)}`;
+}
+
+/** ADMIN: cria um projeto */
+export async function createProjeto(input: ProjetoInput): Promise<Projeto> {
+  const { data, error } = await supabase
+    .from('projetos')
+    .insert({ nome_projeto: input.nome_projeto, nome_cliente: input.nome_cliente, admin_id: input.admin_id ?? null })
+    .select()
+    .single();
+  if (error) throw error;
+  return data as Projeto;
+}
+
+/** ADMIN: adiciona destinatários (gera token UUID no front se token não vier) */
+export async function addDestinatarios(projetoId: string, lista: NovoDestinatario[]) {
+  const payload = lista.map(d => ({
+    projeto_id: projetoId,
+    nome: d.nome,
+    cargo: d.cargo ?? null,
+    email: d.email,
+    token: d.token ?? (globalThis.crypto?.randomUUID?.() ? crypto.randomUUID() : Math.random().toString(36).slice(2)),
+  }));
+  const { data, error } = await supabase.from('destinatarios').insert(payload).select();
+  if (error) throw error;
+  const links = (data || []).map((d: Destinatario) => ({ email: d.email, token: d.token, link: buildResponderLink(d.token) }));
+  return { destinatarios: data as Destinatario[], links };
+}
+
+/** RESPONDENTE: obtém destinatário + projeto via token (para validar link e saber projeto_id) */
+export async function getDestinatarioByToken(token: string) {
+  const { data, error } = await supabase
+    .from('destinatarios')
+    .select('id, projeto_id, nome, email, token, respondido')
+    .eq('token', token)
+    .maybeSingle();
+  if (error) throw error;
+  return data as (Pick<Destinatario, 'id'|'projeto_id'|'nome'|'email'|'token'|'respondido'> | null);
+}
+
+/** RESPONDENTE: envia respostas (INSERT permitido para role anon via policy) */
+export async function submitResposta(params: { token: string; respostas: RespostaPayload }) {
+  const dest = await getDestinatarioByToken(params.token);
+  if (!dest) throw new Error('Link inválido ou expirado.');
+
+  const insert = {
+    projeto_id: dest.projeto_id,
+    destinatario_id: dest.id,
+    respostas_conteudo: params.respostas,
+    validado: false,
+  };
+
+  // Atenção: anon normalmente NÃO pode .select() por causa do RLS; portanto não usamos .select() aqui.
+  const { error } = await supabase.from('respostas').insert(insert);
+  if (error) throw error;
+
+  // opcional: marcar destinatário como respondido
+  await supabase.from('destinatarios').update({ respondido: true }).eq('id', dest.id).throwOnError();
+
+  return { ok: true };
+}
+
+/** ADMIN: lista respostas por projeto (requere role authenticated com policy de SELECT) */
+export async function listRespostasPorProjeto(projetoId: string) {
+  const { data, error } = await supabase
+    .from('respostas')
+    .select('id, projeto_id, destinatario_id, respostas_conteudo, validado, data_resposta')
+    .eq('projeto_id', projetoId)
+    .order('data_resposta', { ascending: false });
+  if (error) throw error;
+  return data as Resposta[];
+}
+
+/** ADMIN: marca/atualiza validação de uma resposta */
+export async function validarResposta(respostaId: string, value = true) {
+  const { error } = await supabase.from('respostas').update({ validado: value }).eq('id', respostaId);
+  if (error) throw error;
+  return { ok: true };
+}

--- a/climada-demo/src/lib/supabaseClient.ts
+++ b/climada-demo/src/lib/supabaseClient.ts
@@ -1,0 +1,12 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+if (!url || !key) {
+  // Ajuda durante build/local
+  // eslint-disable-next-line no-console
+  console.warn('⚠️ Defina NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY no .env');
+}
+
+export const supabase = createClient(url, key);

--- a/climada-demo/src/pages/responder.tsx
+++ b/climada-demo/src/pages/responder.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import { getDestinatarioByToken, submitResposta } from '../lib/esgApi';
+
+export default function ResponderPage() {
+  const router = useRouter();
+  const token = useMemo(() => (router.query.token as string) || '', [router.query.token]);
+  const [loading, setLoading] = useState(true);
+  const [dest, setDest] = useState<{nome:string; email:string}|null>(null);
+  const [erro, setErro] = useState<string|null>(null);
+
+  // Exemplo simples de formulário; substitua pelos campos reais do app
+  const [form, setForm] = useState<{[k:string]: any}>({ pergunta_1: '', pergunta_2: '' });
+  const handleChange = (e: any) => setForm(s => ({ ...s, [e.target.name]: e.target.value }));
+
+  useEffect(() => {
+    if (!token) return;
+    (async () => {
+      try {
+        const d = await getDestinatarioByToken(token);
+        if (!d) throw new Error('Link inválido.');
+        setDest({ nome: d.nome, email: d.email });
+      } catch (e:any) {
+        setErro(e.message || 'Erro ao validar link.');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [token]);
+
+  const onSubmit = async (e:any) => {
+    e.preventDefault();
+    try {
+      await submitResposta({ token, respostas: form });
+      alert('Obrigado! Resposta enviada.');
+      router.replace('/'); // redireciona após envio
+    } catch (e:any) {
+      alert(e.message || 'Falha ao enviar.');
+    }
+  };
+
+  if (loading) return <p>Carregando…</p>;
+  if (erro) return <p style={{color:'crimson'}}>{erro}</p>;
+  return (
+    <main style={{maxWidth:720, margin:'40px auto', padding:'0 16px'}}>
+      <h1>Responder Formulário</h1>
+      <p>Destinatário: <b>{dest?.nome}</b> ({dest?.email})</p>
+      <form onSubmit={onSubmit} style={{display:'grid', gap:12}}>
+        <label>Pergunta 1
+          <input name="pergunta_1" value={form.pergunta_1} onChange={handleChange} required />
+        </label>
+        <label>Pergunta 2
+          <input name="pergunta_2" value={form.pergunta_2} onChange={handleChange} />
+        </label>
+        <button type="submit">Enviar respostas</button>
+      </form>
+    </main>
+  );
+}

--- a/climada-demo/vite.config.js
+++ b/climada-demo/vite.config.js
@@ -1,9 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   base: './',
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
 })
-


### PR DESCRIPTION
## Summary
- adiciona o SDK `@supabase/supabase-js` e configura o alias `@` para facilitar imports compartilhados
- cria cliente Supabase e camada de API (projetos, destinatários, respostas e validação) reutilizável nas telas do admin
- disponibiliza ganchos utilitários para formulários do admin e adiciona a página pública `/responder` consumindo o fluxo de envio

## Testing
- npm run build

## Deploy
Configure as variáveis de ambiente no projeto Vercel (ou `.env.local`):
- `NEXT_PUBLIC_SUPABASE_URL`
- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
- `NEXT_PUBLIC_APP_URL` *(opcional; usado para gerar links de convite; fallback para `window.location.origin`)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e6e5c94c832789b997251002ec35